### PR TITLE
Make variants and products respect various invariants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ src/.idea/*
 tools/LiveSync-*
 .idea/
 .vscode/
+db/umbraco810_done.*

--- a/src/DataSeeding/DataSeedingTaskBase.cs
+++ b/src/DataSeeding/DataSeedingTaskBase.cs
@@ -35,7 +35,7 @@ namespace Ucommerce.Seeder.DataSeeding
 
 
         protected IEnumerable<UCommerceEntityProperty> AddEntityProperty(Guid entityGuid,
-            UCommerceDefinitionField field, string[] languageCodes, Guid[] mediaIds, Guid[] contentIds, string editor,
+            UCommerceDefinitionField field, string[] languageCodes, string[] mediaIds, string[] contentIds, string editor,
             Guid[] enumGuids)
         {
             if (field.Multilingual)

--- a/src/DataSeeding/Tasks/CategorySeedingTask.cs
+++ b/src/DataSeeding/Tasks/CategorySeedingTask.cs
@@ -65,7 +65,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
         }
 
         private async Task<IEnumerable<UCommerceCategory>> GenerateSubCategories(UmbracoDbContext context,
-            int[] definitionIds, Guid[] mediaIds, UCommerceCategory[] topLevelCategories)
+            int[] definitionIds, string[] mediaIds, UCommerceCategory[] topLevelCategories)
         {
             Console.Write($"Generating {4 * Count / 5:N0} subcategories. ");
             using (var p = new ProgressBar())
@@ -82,7 +82,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
 
         private async Task GenerateProperties(UmbracoDbContext context, int[] definitionIds,
             UCommerceCategory[] categories,
-            string[] languageCodes, Guid[] mediaIds)
+            string[] languageCodes, string[] mediaIds)
         {
             var definitionFields = LookupDefinitionFields(context, definitionIds);
             uint estimatedPropertyCount = definitionFields.Any() ? (uint) definitionFields.Average(x => x.Count()) * (uint) categories.Length : 1;
@@ -132,7 +132,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
         }
 
         private async Task<UCommerceCategory[]> GenerateCategories(UmbracoDbContext context, int[] definitionIds,
-            int[] catalogIds, Guid[] mediaIds)
+            int[] catalogIds, string[] mediaIds)
         {
             Console.Write($"Generating {Count / 5:N0} top level categories. ");
             using (var p = new ProgressBar())
@@ -148,7 +148,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
         }
 
         private IEnumerable<UCommerceCategoryProperty> AddCategoryProperty(int categoryId,
-            UCommerceDefinitionField field, string[] languageCodes, Guid[] mediaIds, Guid[] contentIds, string editor,
+            UCommerceDefinitionField field, string[] languageCodes, string[] mediaIds, string[] contentIds, string editor,
             Guid[] enumGuids)
         {
             if (field.Multilingual)
@@ -177,22 +177,22 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
             }
         }
 
-        private UCommerceCategory GenerateCategory(int[] definitionIds, int[] catalogIds, Guid[] mediaIds)
+        private UCommerceCategory GenerateCategory(int[] definitionIds, int[] catalogIds, string[] mediaIds)
         {
             return _categoryFaker
                 .RuleFor(x => x.DefinitionId, f => f.PickRandom(definitionIds))
                 .RuleFor(x => x.ProductCatalogId, f => f.PickRandom(catalogIds))
-                .RuleFor(x => x.ImageMediaId, f => f.PickRandom(mediaIds).ToString())
+                .RuleFor(x => x.ImageMediaId, f => f.PickRandomOrDefault(mediaIds))
                 .Generate();
         }
 
-        private UCommerceCategory GenerateSubCategory(int[] definitionIds, Guid[] mediaIds, UCommerceCategory[] parentCategories)
+        private UCommerceCategory GenerateSubCategory(int[] definitionIds, string[] mediaIds, UCommerceCategory[] parentCategories)
         {
             var parentCategory = _faker.PickRandom(parentCategories);
             return _categoryFaker
                 .RuleFor(x => x.DefinitionId, f => f.PickRandom(definitionIds))
                 .RuleFor(x => x.ProductCatalogId, f => parentCategory.ProductCatalogId)
-                .RuleFor(x => x.ImageMediaId, f => f.PickRandom(mediaIds).ToString())
+                .RuleFor(x => x.ImageMediaId, f => f.PickRandomOrDefault(mediaIds))
                 .RuleFor(x => x.ParentCategoryId, f => parentCategory.CategoryId)
                 .Generate();
         }

--- a/src/DataSeeding/Tasks/Cms/ICmsContent.cs
+++ b/src/DataSeeding/Tasks/Cms/ICmsContent.cs
@@ -5,8 +5,8 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks.Cms
 {
     public interface ICmsContent
     {
-        Guid[] GetAllMediaIds(UmbracoDbContext context);
-        Guid[] GetAllContentIds(UmbracoDbContext context);
+        string[] GetAllMediaIds(UmbracoDbContext context);
+        string[] GetAllContentIds(UmbracoDbContext context);
         string[] GetLanguageIsoCodes(UmbracoDbContext context);
     }
 }

--- a/src/DataSeeding/Tasks/Cms/NullContent.cs
+++ b/src/DataSeeding/Tasks/Cms/NullContent.cs
@@ -5,14 +5,14 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks.Cms
 {
     public class NullContent : ICmsContent
     {
-        public Guid[] GetAllMediaIds(UmbracoDbContext context)
+        public string[] GetAllMediaIds(UmbracoDbContext context)
         {
-            return new[] {Guid.Parse("749039d5-7137-48bd-a400-e11c4bbbaa57")};
+            return new string[0];
         }
 
-        public Guid[] GetAllContentIds(UmbracoDbContext context)
+        public string[] GetAllContentIds(UmbracoDbContext context)
         {
-            return new[] {Guid.Parse("21592d3b-1377-455e-9146-e97b51fb8778")};
+            return new string[0];
         }
 
         public string[] GetLanguageIsoCodes(UmbracoDbContext context)

--- a/src/DataSeeding/Tasks/Cms/UmbracoContent.cs
+++ b/src/DataSeeding/Tasks/Cms/UmbracoContent.cs
@@ -9,18 +9,18 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks.Cms
         public readonly static Guid UmbracoMediaNodeType = new Guid("B796F64C-1F99-4FFB-B886-4BF4BC011A9C");
         public readonly static Guid UmbracoContentNodeType = new Guid("C66BA18E-EAF3-4CFF-8A22-41B16D66A972");
 
-        public virtual Guid[] GetAllMediaIds(UmbracoDbContext context)
+        public virtual string[] GetAllMediaIds(UmbracoDbContext context)
         {
             return context.UmbracoNode
                 .Where(x => x.NodeObjectType == UmbracoMediaNodeType)
-                .Select(x => x.UniqueId).ToArray();
+                .Select(x => x.UniqueId.ToString()).ToArray();
         }
 
-        public virtual Guid[] GetAllContentIds(UmbracoDbContext context)
+        public virtual string[] GetAllContentIds(UmbracoDbContext context)
         {
             return context.UmbracoNode
                 .Where(x => x.NodeObjectType == UmbracoContentNodeType)
-                .Select(x => x.UniqueId).ToArray();
+                .Select(x => x.UniqueId.ToString()).ToArray();
         }
 
         public string[] GetLanguageIsoCodes(UmbracoDbContext context)

--- a/src/DataSeeding/Tasks/Definitions/ProductDefinitionFieldsSeedingTask.cs
+++ b/src/DataSeeding/Tasks/Definitions/ProductDefinitionFieldsSeedingTask.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Bogus;
@@ -26,7 +27,6 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks.Definitions
                 .RuleFor(x => x.Facet, f => f.Random.Bool())
                 .RuleFor(x => x.RenderInEditor, f => f.Random.Bool(0.85f))
                 .RuleFor(x => x.DisplayOnSite, f => f.Random.Bool(0.85f))
-                .RuleFor(x => x.IsVariantProperty, f => f.Random.Bool())
                 .RuleFor(x => x.Searchable, f => f.Random.Bool());
 
             _definitionFieldDescriptionFaker = new Faker<UCommerceProductDefinitionFieldDescription>()
@@ -39,6 +39,43 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks.Definitions
         {
             var fields = await GenerateDefinitionFields(context);
             await GenerateFieldDescriptions(context, fields);
+        }
+
+
+        private async Task<UCommerceProductDefinitionField[]> GenerateDefinitionFields(UmbracoDbContext context)
+        {
+            Console.Write($"Generating {Count:N0} product definition fields. ");
+            using (var p = new ProgressBar())
+            {
+                var dataTypeIds = context.UCommerceDataType.Select(x => x.DataTypeId).ToArray();
+
+                var allProductDefinitionIds =
+                    context.UCommerceProductDefinition.Select(x => x.ProductDefinitionId).ToList();
+                var oneHalfProductDefinitionIds =
+                    allProductDefinitionIds.Take(allProductDefinitionIds.Count / 2).ToList();
+                var oneHalfProductFamiliyDefinitionIds =
+                    allProductDefinitionIds.Skip(allProductDefinitionIds.Count / 2).ToList();
+
+                UCommerceProductDefinitionField[] familyDefinitionFields = GeneratorHelper.Generate(
+                    () => GenerateDefinitionFieldForFamily(oneHalfProductFamiliyDefinitionIds, dataTypeIds), Count / 2);
+                
+                UCommerceProductDefinitionField[] definitionFields = GeneratorHelper.Generate(
+                    () => GenerateDefinitionFieldForNonFamily(oneHalfProductDefinitionIds, dataTypeIds), Count / 2);
+
+                var allFields = familyDefinitionFields.Concat(definitionFields).ToArray();
+                p.Report(0.25);
+
+                allFields.ConsecutiveSortOrder((f, v) => { f.SortOrder = (int) v; });
+                p.Report(0.50);
+
+                allFields = allFields
+                    .Where(f => f.Name != "name")
+                    .DistinctBy(f => new CompositeKey {Key1 = f.Name.GetHashCode(), Key2 = f.ProductDefinitionId})
+                    .ToArray();
+                p.Report(0.75);
+                await context.BulkInsertAsync(allFields);
+                return allFields;
+            }
         }
 
         private async Task GenerateFieldDescriptions(UmbracoDbContext context, UCommerceProductDefinitionField[] fields)
@@ -60,37 +97,23 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks.Definitions
             }
         }
 
-        private async Task<UCommerceProductDefinitionField[]> GenerateDefinitionFields(UmbracoDbContext context)
-        {
-            Console.Write($"Generating {Count:N0} product definition fields. ");
-            using (var p = new ProgressBar())
-            {
-                var productDefinitionIds =
-                    context.UCommerceProductDefinition.Select(x => x.ProductDefinitionId).ToArray();
-                var dataTypeIds = context.UCommerceDataType.Select(x => x.DataTypeId).ToArray();
-
-                var fields =
-                    GeneratorHelper.Generate(() => GenerateDefinitionField(productDefinitionIds, dataTypeIds), Count);
-                p.Report(0.25);
-
-                fields.ConsecutiveSortOrder((f, v) => { f.SortOrder = (int) v; });
-                p.Report(0.50);
-
-                fields = fields
-                    .Where(f => f.Name != "name")
-                    .DistinctBy(f => new CompositeKey {Key1 = f.Name.GetHashCode(), Key2 = f.ProductDefinitionId})
-                    .ToArray();
-                p.Report(0.75);
-                await context.BulkInsertAsync(fields);
-                return fields;
-            }
-        }
-
-        private UCommerceProductDefinitionField GenerateDefinitionField(int[] productDefinitionIds, int[] dataTypeIds)
+        private UCommerceProductDefinitionField GenerateDefinitionFieldForFamily(List<int> productDefinitionIds,
+            int[] dataTypeIds)
         {
             return _productDefinitionFieldFaker
                 .RuleFor(x => x.ProductDefinitionId, f => f.PickRandom(productDefinitionIds))
                 .RuleFor(x => x.DataTypeId, f => f.PickRandom(dataTypeIds))
+                .RuleFor(x => x.IsVariantProperty, f => f.Random.Bool(0.75f))
+                .Generate();
+        }
+
+        private UCommerceProductDefinitionField GenerateDefinitionFieldForNonFamily(List<int> productDefinitionIds,
+            int[] dataTypeIds)
+        {
+            return _productDefinitionFieldFaker
+                .RuleFor(x => x.ProductDefinitionId, f => f.PickRandom(productDefinitionIds))
+                .RuleFor(x => x.DataTypeId, f => f.PickRandom(dataTypeIds))
+                .RuleFor(x => x.IsVariantProperty, f => false)
                 .Generate();
         }
     }

--- a/src/DataSeeding/Tasks/ProductSeedingTask.cs
+++ b/src/DataSeeding/Tasks/ProductSeedingTask.cs
@@ -215,8 +215,8 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
         }
 
         protected async Task GenerateProperties(UmbracoDbContext context, UCommerceProduct[] products,
-            ILookup<int, ProductDefinitionFieldEditorAndEnum> productDefinitionFields, Guid[] mediaIds,
-            Guid[] contentIds)
+            ILookup<int, ProductDefinitionFieldEditorAndEnum> productDefinitionFields, string[] mediaIds,
+            string[] contentIds)
         {
             uint averageNumberOfFieldsPerProduct = productDefinitionFields.Any()
                 ? (uint) productDefinitionFields.Average(f => f.Count()) / 2
@@ -264,7 +264,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
         }
 
         protected async Task<UCommerceProduct[]> GenerateProducts(UmbracoDbContext context, int[] productDefinitionIds,
-            string[] languageCodes, Guid[] mediaIds)
+            string[] languageCodes, string[] mediaIds)
         {
             Console.Write($"Generating {Count:N0} products. ");
             using (var p = new ProgressBar())
@@ -323,7 +323,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
 
         protected UCommerceProductDescriptionProperty[] GenerateLanguageVariantProductProperties(
             IEnumerable<int> descriptionIds,
-            IEnumerable<ProductDefinitionFieldEditorAndEnum> fields, Guid[] mediaIds, Guid[] contentIds)
+            IEnumerable<ProductDefinitionFieldEditorAndEnum> fields, string[] mediaIds, string[] contentIds)
         {
             return fields
                 .Where(field => field.Field.Multilingual)
@@ -340,7 +340,7 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
         }
 
         protected UCommerceProductProperty[] GenerateLanguageInvariantProductProperties(int productId,
-            IEnumerable<ProductDefinitionFieldEditorAndEnum> fields, Guid[] mediaIds, Guid[] contentIds)
+            IEnumerable<ProductDefinitionFieldEditorAndEnum> fields, string[] mediaIds, string[] contentIds)
         {
             return fields
                 .Where(field => !field.Field.Multilingual)
@@ -353,12 +353,12 @@ namespace Ucommerce.Seeder.DataSeeding.Tasks
                         .Generate()).ToArray();
         }
 
-        protected UCommerceProduct GenerateProduct(int[] productDefinitionIds, string[] languageCodes, Guid[] mediaIds)
+        protected UCommerceProduct GenerateProduct(int[] productDefinitionIds, string[] languageCodes, string[] mediaIds)
         {
             var product = _productFaker
                 .RuleFor(x => x.ProductDefinitionId, f => f.PickRandom(productDefinitionIds))
-                .RuleFor(x => x.PrimaryImageMediaId, f => f.PickRandom(mediaIds).ToString())
-                .RuleFor(x => x.ThumbnailImageMediaId, f => f.PickRandom(mediaIds).ToString())
+                .RuleFor(x => x.PrimaryImageMediaId, f => f.PickRandomOrDefault(mediaIds))
+                .RuleFor(x => x.ThumbnailImageMediaId, f => f.PickRandomOrDefault(mediaIds))
                 .Generate();
 
             return product;

--- a/src/DataSeeding/Utilities/BogusExtensions.cs
+++ b/src/DataSeeding/Utilities/BogusExtensions.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ucommerce.Seeder.DataSeeding.Utilities
+{
+    public static class BogusExtensions
+    {
+        public static T PickRandomOrDefault<T>(this Bogus.Faker faker, IEnumerable<T> items)
+        {
+            if (!items.Any())
+            {
+                return default(T);
+            }
+            return faker.Random.ArrayElement(items.ToArray());
+        }
+
+        public static IEnumerable<T> PickRandomOrDefault<T>(this Bogus.Faker faker, IEnumerable<T> items, int quantity)
+        {
+            if (!items.Any())
+            {
+                return new T[0];
+            }
+
+            return faker.PickRandom(items, quantity);
+        }
+
+    }
+}

--- a/src/DataSeeding/Utilities/BogusProperty.cs
+++ b/src/DataSeeding/Utilities/BogusProperty.cs
@@ -7,28 +7,28 @@ namespace Ucommerce.Seeder.DataSeeding.Utilities
     public static class BogusProperty
     {
         private static readonly Dictionary<BuiltInEditors,
-            Func<IEnumerable<Guid>, IEnumerable<Guid>, IEnumerable<Guid>, string>> _values =
-            new Dictionary<BuiltInEditors, Func<IEnumerable<Guid>, IEnumerable<Guid>, IEnumerable<Guid>, string>>
+            Func<IEnumerable<string>, IEnumerable<string>, IEnumerable<Guid>, string>> _values =
+            new Dictionary<BuiltInEditors, Func<IEnumerable<string>, IEnumerable<string>, IEnumerable<Guid>, string>>
             {
                 {BuiltInEditors.RichText, (mediaGuids, contentGuids, enumGuids) => _faker.Lorem.Paragraphs(3)},
                 {
                     BuiltInEditors.Media,
-                    (mediaGuids, contentGuids, enumGuids) => _faker.PickRandom(mediaGuids).ToString()
+                    (mediaGuids, contentGuids, enumGuids) => _faker.PickRandomOrDefault(mediaGuids)
                 },
                 {
                     BuiltInEditors.Content,
-                    (mediaGuids, contentGuids, enumGuids) => _faker.PickRandom(contentGuids).ToString()
+                    (mediaGuids, contentGuids, enumGuids) => _faker.PickRandomOrDefault(contentGuids)
                 },
                 {
                     BuiltInEditors.EmailContent,
-                    (mediaGuids, contentGuids, enumGuids) => _faker.PickRandom(contentGuids).ToString()
+                    (mediaGuids, contentGuids, enumGuids) => _faker.PickRandomOrDefault(contentGuids)
                 },
                 {BuiltInEditors.DateTime, (mediaGuids, contentGuids, enumGuids) => _faker.Date.Recent().ToString()},
                 {BuiltInEditors.Boolean, (mediaGuids, contentGuids, enumGuids) => _faker.Random.Bool().ToString()},
                 {
                     BuiltInEditors.ImagePickerMultiSelect,
                     (mediaGuids, contentGuids, enumGuids) =>
-                        String.Join("|", _faker.PickRandom(mediaGuids, _faker.Random.UShort(0, 5)))
+                        String.Join("|", _faker.PickRandomOrDefault(mediaGuids, _faker.Random.UShort(0, 5)))
                 },
                 {BuiltInEditors.ShortText, (mediaGuids, contentGuids, enumGuids) => _faker.Lorem.Sentence()},
                 {BuiltInEditors.LongText, (mediaGuids, contentGuids, enumGuids) => _faker.Lorem.Sentences(3)},
@@ -53,7 +53,7 @@ namespace Ucommerce.Seeder.DataSeeding.Utilities
         // ReSharper disable once InconsistentNaming
         private static readonly Faker _faker = new Faker();
 
-        public static string BogusValue(IEnumerable<Guid> mediaGuids, IEnumerable<Guid> contentGuids, string editor,
+        public static string BogusValue(IEnumerable<string> mediaGuids, IEnumerable<string> contentGuids, string editor,
             IEnumerable<Guid> enums)
         {
             if (Enum.TryParse(editor, out BuiltInEditors editorEnum))

--- a/src/Ucommerce.Seeder.sln.DotSettings
+++ b/src/Ucommerce.Seeder.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ucommerce/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
fix #5 

Now, all generated variants are children of products that are product families. Do achieve this, the product definition field seeding tasks distinguishes btw product definitions for products and those for product families.

also fix #3

seems to somehow also fix #4 