### PR TITLE
medium_db_user_defined_values

### DIFF
--- a/src/DataSeeding/DataSeedingTaskBase.cs
+++ b/src/DataSeeding/DataSeedingTaskBase.cs
@@ -66,13 +66,15 @@ namespace Ucommerce.Seeder.DataSeeding
         
         protected ILookup<int, DefinitionFieldEditorAndEnum> LookupDefinitionFields(UmbracoDbContext context, int[] definitionIds)
         {
-            return context.UCommerceDefinitionField
-                .Where(field => definitionIds.Contains(field.DefinitionId))
+            var uCommerceDefinitionFields = context.UCommerceDefinitionField
+                .Where(field => definitionIds.Contains(field.DefinitionId));
+                
+            return uCommerceDefinitionFields
                 .Select(field => new DefinitionFieldEditorAndEnum(field,
-                    field.DataType.Definition.UCommerceDefinitionField.Where(x => x.Name == "Editor").Any() ? field.DataType.Definition.UCommerceDefinitionField.Where(x => x.Name == "Editor").First()
-                        .UCommerceEntityProperty.Where(x => x.EntityId == field.DataType.Guid).Select(x => x.Value).FirstOrDefault() : "",
-                    field.DataType.UCommerceDataTypeEnum.Select(x => x.Guid)))
-                .ToLookup(field => field.Field.DefinitionId);
+                    field.DataType.DefinitionName,
+                    field.DataType.UCommerceDataTypeEnum
+                        .Select(x => x.Guid)))
+                        .ToLookup(field => field.Field.DefinitionId);
         }
     }
 }

--- a/src/DataSeeding/Utilities/BogusProperty.cs
+++ b/src/DataSeeding/Utilities/BogusProperty.cs
@@ -23,7 +23,7 @@ namespace Ucommerce.Seeder.DataSeeding.Utilities
                     BuiltInEditors.EmailContent,
                     (mediaGuids, contentGuids, enumGuids) => _faker.PickRandomOrDefault(contentGuids)
                 },
-                {BuiltInEditors.DateTime, (mediaGuids, contentGuids, enumGuids) => _faker.Date.Recent().ToString()},
+                {BuiltInEditors.Date, (mediaGuids, contentGuids, enumGuids) => _faker.Date.Recent().ToString()},
                 {BuiltInEditors.Boolean, (mediaGuids, contentGuids, enumGuids) => _faker.Random.Bool().ToString()},
                 {
                     BuiltInEditors.ImagePickerMultiSelect,
@@ -58,10 +58,9 @@ namespace Ucommerce.Seeder.DataSeeding.Utilities
         {
             if (Enum.TryParse(editor, out BuiltInEditors editorEnum))
             {
-                return _values[editorEnum](mediaGuids, contentGuids, enums);
+                return _values[editorEnum](mediaGuids, contentGuids, enums) ?? "";
             }
-
-            return "";
+            return _faker.Lorem.Word();
         }
     }
 }

--- a/src/DataSeeding/Utilities/BuiltInEditors.cs
+++ b/src/DataSeeding/Utilities/BuiltInEditors.cs
@@ -6,7 +6,7 @@ namespace Ucommerce.Seeder.DataSeeding.Utilities
         Media,
         Content,
         EmailContent,
-        DateTime,
+        Date,
         Boolean,
         ImagePickerMultiSelect,
         ShortText,

--- a/src/DatabaseSize.cs
+++ b/src/DatabaseSize.cs
@@ -113,7 +113,7 @@ namespace Ucommerce.Seeder
 
         public static readonly DatabaseSize Medium = new DatabaseSize
         {
-            DataTypes = 0,
+            DataTypes = 5,
             ProductDefinitions = 5,
             Definitions = 10,
             ProductRelationTypes = 3,


### PR DESCRIPTION
Fixed so that medium size DB will now contain user defined values.

Medium size DB now creates 5 randomized DateTypes.

Changed enum for DateTime to Date, as this is the name used as definitionName for type DatePicker.

If no value is found, value is set to _faker.Loren.Word()

EnumMultiSelect can still have a value of 0, which results in empty values, so mimic real world scenarios better.