### PR TITLE
chore: changed the help text for size argument to include all sizes

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Reflection;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace Ucommerce.Seeder
@@ -19,7 +21,7 @@ namespace Ucommerce.Seeder
 
             CommandOption<DbSizeOption> sizeArgument = 
                 app.Option<DbSizeOption>("-s|--size=<SIZE>", 
-                    "The size of the database, either 'huge', 'large' or 'medium'. Default is 'huge'.", CommandOptionType.SingleOrNoValue);
+                    $"The size of the database, the options are {typeof(DbSizeOption).GetMembers(BindingFlags.Public | BindingFlags.Static).Select(x => x.Name).ToArray().Aggregate("\n", (current, s) => current + s + "\n")}Default is '{DbSizeOption.Huge.ToString()}'.", CommandOptionType.SingleOrNoValue);
 
             CommandOption<bool> verboseArgument = 
                 app.Option<bool>("-v|--verbose", 


### PR DESCRIPTION
Help text was missing some size options, changed it to use all defined size options names instead of a specific string.

Old:
<img width="625" alt="Old" src="https://user-images.githubusercontent.com/106595231/225327428-3e99ff27-5aaf-4091-8462-c336106fc87b.PNG">
New:
<img width="599" alt="New" src="https://user-images.githubusercontent.com/106595231/225327460-569402a2-0e8e-4e52-be50-72e75e424659.PNG">